### PR TITLE
docs: add portfolio context recovery note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,3 +23,47 @@
 ## Verification Contract
 - Canonical commands are in `.codex/verify.commands`.
 - Use `.codex/scripts/run_verify_commands.sh` for deterministic execution.
+
+<!-- portfolio-context:start -->
+# Portfolio Context
+
+## What This Project Is
+
+DesktopPet is a Tauri desktop companion that turns focus sessions into a pet progression loop. A transparent always-on-top pet overlay, controls panel, Pomodoro presets, XP/coins, quests, shop unlocks, and focus guardrails work together as a local desktop productivity game.
+
+## Current State
+
+The repo is active desktop product work. Existing local changes are PR-template metadata, so context recovery should stay documentation-only.
+
+## Stack
+
+| Layer | Technology |
+|-------|------------|
+| Shell | Tauri 2 (Rust backend) |
+| Language | TypeScript + React |
+| Bundler | Vite |
+| Testing | Vitest |
+| Styling | Tailwind CSS |
+
+## How To Run
+
+```bash
+# Development
+npm run dev
+
+# Production build
+npm run build
+```
+
+## Known Risks
+
+- Focus guardrails affect user workflow; avoid blocking behavior without clear controls and tests.
+- Pet, quest, shop, and focus-session state crosses TypeScript stores and the Rust layer, so keep persistence boundaries explicit.
+- Transparent always-on-top windows can be fragile on desktop platforms; verify overlay behavior after UI changes.
+- Keep PR-template drift separate from product changes.
+
+## Next Recommended Move
+
+Resolve the PR-template drift separately, then verify overlay, Pomodoro, quest/shop, and focus-guardrail flows before shipping behavior changes.
+
+<!-- portfolio-context:end -->


### PR DESCRIPTION
## What
- Adds a managed portfolio-context block to AGENTS.md.

## Why
- Closes a GithubRepoAuditor context recovery item while leaving unrelated local work untouched.

## How
- Documentation-only update based on the README.

## Testing
- `git diff --check -- AGENTS.md`
- Placeholder scan for generic filler

## Performance Impact
- None expected.

## Risk / Notes
- Documentation-only.