### PR TITLE
ci: add CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,36 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+  schedule:
+    - cron: '37 8 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## What

- Adds a CodeQL workflow for JavaScript/TypeScript analysis.
- Runs on PRs, pushes to main, weekly schedule, and manual dispatch.

## Why

Security Review flagged this repo as missing GitHub code scanning coverage for a CodeQL-supported language surface.

## How

Uses the standard CodeQL action with read-only contents permission and SARIF upload permission.

## Testing

Pending GitHub PR checks.

## Performance Impact

None expected for application runtime; adds CI scan time only.

## Risk / Notes

Config-only security coverage change. Merge only after PR checks pass.