### PR TITLE
ci: exempt dependency bot branches from human gates

### DIFF
--- a/.github/workflows/git-hygiene.yml
+++ b/.github/workflows/git-hygiene.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   commitlint:
+    if: ${{ !startsWith(github.head_ref, 'dependabot/') && !startsWith(github.head_ref, 'renovate/') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -26,6 +27,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   branch-name:
+    if: ${{ !startsWith(github.head_ref, 'dependabot/') && !startsWith(github.head_ref, 'renovate/') }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/.github/workflows/lockfile-rationale.yml
+++ b/.github/workflows/lockfile-rationale.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   enforce:
+    if: ${{ !startsWith(github.head_ref, 'dependabot/') && !startsWith(github.head_ref, 'renovate/') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Exempt Dependabot/Renovate branches from human-only commitlint and branch-name gates
- Exempt dependency bot branches from lockfile-rationale enforcement
- Keep PR title and secrets checks active

## Validation
- npm run git:guard:branch && npm run git:guard:atomic && npm run git:guard:generated && npm run git:guard:large-files && npm run git:guard:secrets