### PR TITLE
chore(deps): add Cargo Dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/src-tauri"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

- add weekly Cargo dependency updates for the Tauri manifest
- preserve the repository existing Dependabot policy where present
- prepare automatic update coverage for the open glib security advisory

## Verification

- Dependabot YAML parses successfully
- Cargo manifest directory verified at /src-tauri

This adds update coverage only; it does not suppress or dismiss the existing security alert.