### PR TITLE
ci(git-hygiene): run the branch guard instead of restating its rule

### DIFF
--- a/.github/workflows/git-hygiene.yml
+++ b/.github/workflows/git-hygiene.yml
@@ -30,16 +30,15 @@ jobs:
     if: ${{ !startsWith(github.head_ref, 'dependabot/') && !startsWith(github.head_ref, 'renovate/') }}
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: read
+      contents: read
     steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
-        with:
-          script: |
-            const branch = context.payload.pull_request?.head?.ref || "";
-            const pattern = /^codex\/(feat|fix|chore|refactor|docs|test|perf|ci|spike|hotfix)\/[a-z0-9]+(?:-[a-z0-9]+)*$/;
-            if (!pattern.test(branch)) {
-              core.setFailed(`Invalid branch name: ${branch}`);
-            }
+      # Runs the repository's own guard rather than restating its rule. This job
+      # carried a second copy of the branch pattern and the two had drifted: the
+      # guard accepts <type>/<slug> and <agent>/<task-slug>, this copy accepted
+      # neither, so a branch the local hook blessed failed here. One rule, one
+      # place, pinned by the guard's own test suite.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - run: bash scripts/git/guard-branch.sh
 
   secrets:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Makes the `branch-name` CI job run this repository's own branch guard instead of
carrying a second copy of its rule.

This repository just landed `scripts/git/guard-branch.sh`, which accepts
`<type>/<slug>`, `codex/<type>/<slug>` and `<agent>/<task-slug>`. The
`branch-name` job still held its own regex accepting **only**
`codex/<type>/<slug>`. So a branch the local pre-commit hook blessed failed in
CI — one rule, in two places, already drifted, and only the untested copy gates
a pull request.

The job now checks out the repository and runs the guard. The `dependabot/` and
`renovate/` job-level exemptions stay; the guard handles `dependabot` and
`release-please` itself. The job's permission drops from `pull-requests: read`
to `contents: read`, because it reads files now rather than the pull request API.

**Trade-off worth naming.** The guard is read from the pull request's own
checkout, so a pull request could in principle weaken the check it is subject
to. The inline copy could not be edited that way. This repository takes no
external contributions, the `pull_request` token is read-only, and the
`commitlint` job in this same workflow already runs against the pull request's
checkout — so the exposure is not new, but it is real. Pinning the guard to the
base commit would close it, at the cost of breaking any repository where a
pull request is what first introduces the script.

No untrusted input is interpolated into a `run:` step. The guard reads
`GITHUB_HEAD_REF` from the environment.

**Verified.** The workflow parses, and the guard was exercised in this checkout
under CI environment variables against four branch names it must accept —
including the two shapes that were failing here — and three it must reject. All
seven behaved correctly. Across the ten repositories getting this change that is
70 guard invocations, all correct.

CI only. No source, test, or configuration file outside `.github/workflows/` is
touched.
